### PR TITLE
Support for non-ASCII folder names

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -48,6 +48,8 @@ requires 'MIME::Words';
 requires 'Try::Tiny';
 requires 'Try::Tiny::SmartCatch';
 
+requires 'Encode::IMAPUTF7';
+
 requires 'Email::Simple';
 requires 'Email::Sender';
 requires 'Email::Valid';

--- a/lib/CiderWebmail/Model/IMAPClient.pm
+++ b/lib/CiderWebmail/Model/IMAPClient.pm
@@ -646,7 +646,7 @@ sub delete_messages {
     $self->_imapclient->delete_message($o->{uids});
     $self->_die_on_error();
 
-    $self->_imapclient->expunge($o->{mailbox});
+    $self->_imapclient->expunge(Encode::IMAPUTF7::encode('IMAP-UTF-7',$o->{mailbox}));
     $self->_die_on_error();
 
     return;


### PR DESCRIPTION
IMAP uses modified UTF-7 encoding as described in RFC 2060 to store non-ascii symbols in the folder names. As of version 1.05 ciderwebnmail displays cyrillic folder names utf-7 encoded, i.e. compieyely unreadable.

There is CPAN module Encode::IMAPUTF7 to handle conversion to/from this encoding.

This commit adds calls to Encode::IMAPUTF7::decode to folder_tree function and Encode::IMAPUTF7::decode whereever folder names are passed to $self->_imapclient methods.